### PR TITLE
update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,5 +72,5 @@ source 'https://rails-assets.org' do
 end
 
 gem 'devise'
-gem 'rubocop', require: false
 gem 'rubocop-performance'
+gem 'ffi', '~> 1.11', '>= 1.11.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,7 +97,7 @@ GEM
     factory_bot_rails (5.0.2)
       factory_bot (~> 5.0.2)
       railties (>= 4.2.0)
-    ffi (1.11.0)
+    ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.6.0)
@@ -266,6 +266,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   factory_bot_rails
+  ffi (~> 1.11, >= 1.11.1)
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
@@ -275,7 +276,6 @@ DEPENDENCIES
   rails (~> 5.2.3)
   rails-assets-tether (>= 1.3.3)!
   rspec-rails (~> 3.8)
-  rubocop
   rubocop-performance
   sass-rails (~> 5.0)
   selenium-webdriver


### PR DESCRIPTION
The ffi gem owners deleted the version of the gem we had in the `Gemfile.lock`. See my note in Slack for more details. I also deleted the outdated rubocop gem, as that was not needed. 